### PR TITLE
GitHub Actions Job Timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 10
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Add timeout configuration to GH Action Jobs to prevent consuming excessive GH action time. Default timeout if unspecified is 360 minutes.